### PR TITLE
feat: warm up Juju VM images during testenv install

### DIFF
--- a/src/cephtools/testenv.py
+++ b/src/cephtools/testenv.py
@@ -1010,6 +1010,147 @@ def _restart_system_resolver() -> None:
     run("sudo systemctl restart systemd-resolved || true", shell=True, check=False)
 
 
+# Bases warmed by juju_warmup(). Juju fetches each base's VM image lazily on
+# first deploy; a cold fetch under load can stall provisioning (GH run
+# 29607039184). Defaults cover every base the ceph-qa predeployed matrix uses.
+JUJU_WARMUP_BASES = ("ubuntu@22.04", "ubuntu@24.04", "ubuntu@26.04")
+JUJU_WARMUP_VM_CONSTRAINTS = "virt-type=virtual-machine mem=4G root-disk=32G"
+JUJU_WARMUP_TIMEOUT_SECONDS = 600
+JUJU_WARMUP_POLL_INTERVAL_SECONDS = 10
+
+
+def _warmup_model_name(base: str) -> str:
+    """Map a base (ubuntu@24.04) to a valid Juju model name (warmup-ubuntu-24-04)."""
+    return "warmup-" + base.replace("@", "-").replace(".", "-")
+
+
+def _destroy_warmup_model(controller: str, model: str) -> None:
+    run(
+        [
+            "juju",
+            "destroy-model",
+            f"{controller}:{model}",
+            "--force",
+            "--no-wait",
+            "--destroy-storage",
+            "--no-prompt",
+        ],
+        check=False,
+    )
+
+
+def _wait_for_warmup_machine(
+    controller: str,
+    model: str,
+    timeout_seconds: int,
+    poll_interval_seconds: int,
+) -> None:
+    """Poll juju status until machine 0 is started, else raise TimeoutError."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        res = run(
+            ["juju", "status", "--model", f"{controller}:{model}", "--format", "json"],
+            check=False,
+        )
+        if res.returncode == 0 and res.stdout:
+            try:
+                payload = json.loads(res.stdout)
+                machines = (
+                    payload.get("machines") if isinstance(payload, dict) else None
+                )
+                m0 = machines.get("0") if isinstance(machines, dict) else None
+                if isinstance(m0, dict):
+                    status = m0.get("machine-status", {})
+                    if isinstance(status, dict) and status.get("status") == "started":
+                        return
+            except (json.JSONDecodeError, AttributeError):
+                pass  # transient parse issue; keep polling
+        time.sleep(poll_interval_seconds)
+    raise TimeoutError(f"warmup machine not started within {timeout_seconds}s")
+
+
+def juju_warmup(
+    bases: tuple[str, ...] = JUJU_WARMUP_BASES,
+    *,
+    controller: str = LXD_CONTROLLER,
+    vm_constraints: str = JUJU_WARMUP_VM_CONSTRAINTS,
+    timeout_seconds: int = JUJU_WARMUP_TIMEOUT_SECONDS,
+    poll_interval_seconds: int = JUJU_WARMUP_POLL_INTERVAL_SECONDS,
+) -> None:
+    """Pre-cache Juju's per-base VM images by adding then removing a machine.
+
+    Juju fetches each base's VM image lazily on first deploy of that base; a
+    cold fetch under load can stall provisioning (GH run 29607039184). Warming
+    during ``testenv install`` (reserve time) populates the cache so the first
+    matrix job starts warm. Best-effort: any failure emits a warning and moves
+    on -- it must never fail the install. LXD substrate only; MAAS commissions
+    real machines rather than LXD VMs, so warmup does not apply there.
+    """
+    for base in bases:
+        model = _warmup_model_name(base)
+        click.echo(f"Warming up Juju VM image for {base} (model {model})...")
+        _destroy_warmup_model(controller, model)  # clean any leftover
+
+        add = run(
+            [
+                "juju",
+                "add-model",
+                model,
+                "--no-switch",
+                "--config",
+                f"default-base={base}",
+                "--controller",
+                controller,
+            ],
+            check=False,
+        )
+        if add.returncode != 0:
+            click.echo(
+                f"Warning: warmup add-model for {base} failed (rc={add.returncode}); "
+                f"skipping. Output:\n{add.stdout}"
+            )
+            continue
+
+        run(
+            [
+                "juju",
+                "set-model-constraints",
+                "--model",
+                f"{controller}:{model}",
+                vm_constraints,
+            ],
+            check=False,
+        )
+
+        try:
+            add_machine = run(
+                [
+                    "juju",
+                    "add-machine",
+                    "--base",
+                    base,
+                    "--model",
+                    f"{controller}:{model}",
+                ],
+                check=False,
+            )
+            if add_machine.returncode != 0:
+                click.echo(
+                    f"Warning: warmup add-machine for {base} failed "
+                    f"(rc={add_machine.returncode}); skipping. Output:\n{add_machine.stdout}"
+                )
+                continue
+
+            _wait_for_warmup_machine(
+                controller, model, timeout_seconds, poll_interval_seconds
+            )
+            click.echo(f"Warmed up Juju VM image for {base}.")
+        except Exception as exc:  # best-effort: never fail install
+            click.echo(f"Warning: warmup for {base} did not complete: {exc}")
+        finally:
+            _destroy_warmup_model(controller, model)
+
+
 def _lxd_instance_exists(name: str) -> bool:
     result = run(["lxc", "info", name], check=False, quiet=True)
     return result.returncode == 0
@@ -3928,6 +4069,11 @@ def install(ctx):
                 "configure-network",
                 "Configuring network",
                 lambda: ctx.invoke(configure_network),
+            ),
+            (
+                "warmup-juju-images",
+                "Warming up Juju VM images",
+                lambda: juju_warmup(),
             ),
         ]
     else:

--- a/tests/test_testenv.py
+++ b/tests/test_testenv.py
@@ -3080,3 +3080,162 @@ def test_register_vm_host_cli_is_noop_for_lxd(
 
     assert result.exit_code == 0
     assert "skipped for --substrate lxd" in result.output
+
+
+# ---------------------------------------------------------------------------
+# juju_warmup
+# ---------------------------------------------------------------------------
+
+
+class _RunResult:
+    def __init__(self, stdout: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+def _warmup_run_recorder(calls, *, status_payloads):
+    """Fake testenv.run that drives juju_warmup through to completion.
+
+    For each base, add-model/add-machine/set-model-constraints/destroy-model
+    return success, and `juju status --format json` returns a payload whose
+    machine 0 becomes "started" after one poll.
+    """
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+
+        if cmd[:2] == ["juju", "destroy-model"]:
+            return _RunResult()
+        if cmd[:2] == ["juju", "add-model"]:
+            return _RunResult()
+        if cmd[:2] == ["juju", "set-model-constraints"]:
+            return _RunResult()
+        if cmd[:2] == ["juju", "add-machine"]:
+            return _RunResult()
+        if cmd[:2] == ["juju", "status"]:
+            return _RunResult(stdout=status_payloads.pop(0))
+        raise AssertionError(f"unexpected run: {cmd}")
+
+    return fake_run
+
+
+def test_juju_warmup_caches_each_base_and_destroys_models(monkeypatch):
+    calls: list[list[str]] = []
+    started = json.dumps({"machines": {"0": {"machine-status": {"status": "started"}}}})
+    # One "started" status payload per base (the warmup polls exactly once).
+    payloads = [started, started, started]
+    monkeypatch.setattr(
+        testenv, "run", _warmup_run_recorder(calls, status_payloads=payloads)
+    )
+    monkeypatch.setattr(testenv.time, "sleep", lambda *a, **k: None)
+
+    testenv.juju_warmup()
+
+    # For each base: destroy(cleanup) + add-model + set-constraints + add-machine
+    # + destroy(final). Status polls happen via `run` too.
+    destroys = [c for c in calls if c[:2] == ["juju", "destroy-model"]]
+    add_models = [c for c in calls if c[:2] == ["juju", "add-model"]]
+    add_machines = [c for c in calls if c[:2] == ["juju", "add-machine"]]
+    assert len(add_models) == 3
+    assert len(add_machines) == 3
+    # one cleanup destroy before + one final destroy after, per base
+    assert len(destroys) == 6
+
+    # Each add-machine targets its base and the warmup model on lxd-controller.
+    for base, cmd in zip(
+        ("ubuntu@22.04", "ubuntu@24.04", "ubuntu@26.04"), add_machines
+    ):
+        assert "--base" in cmd
+        assert base in cmd
+        assert "lxd-controller:warmup-ubuntu-" in " ".join(cmd)
+
+
+def test_juju_warmup_is_best_effort_on_add_model_failure(monkeypatch):
+    """A failed add-model must warn and continue, never raise."""
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["juju", "add-model"]:
+            return _RunResult(stdout="boom", returncode=2)
+        return _RunResult()
+
+    monkeypatch.setattr(testenv, "run", fake_run)
+    monkeypatch.setattr(testenv.time, "sleep", lambda *a, **k: None)
+
+    # Must not raise.
+    testenv.juju_warmup()
+
+
+def test_juju_warmup_is_best_effort_on_timeout(monkeypatch):
+    """A machine that never starts must warn and continue, never raise."""
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["juju", "status"]:
+            # machine stuck pending forever
+            return _RunResult(
+                stdout=json.dumps(
+                    {"machines": {"0": {"machine-status": {"status": "pending"}}}}
+                )
+            )
+        return _RunResult()
+
+    monkeypatch.setattr(testenv, "run", fake_run)
+    monkeypatch.setattr(testenv.time, "sleep", lambda *a, **k: None)
+
+    # Short timeout so the test doesn't wait the full default. Must not raise;
+    # the timed-out base's model is still destroyed via the finally block.
+    testenv.juju_warmup(timeout_seconds=0, poll_interval_seconds=0)
+
+
+def test_juju_warmup_model_name_is_valid():
+    assert testenv._warmup_model_name("ubuntu@24.04") == "warmup-ubuntu-24-04"
+    assert testenv._warmup_model_name("ubuntu@26.04") == "warmup-ubuntu-26-04"
+
+
+def test_install_runs_juju_warmup_for_lxd_substrate(monkeypatch):
+    """The LXD install sequence must include a juju warmup step."""
+    runner = CliRunner()
+
+    # Short-circuit every install step so we can assert the step list runs.
+    monkeypatch.setattr(testenv, "install_fault_handlers", lambda name: None)
+    monkeypatch.setattr(testenv, "install_deps", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "lxd_init_cmd", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "juju_init", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "configure_network", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "_ensure_model_for_substrate", lambda *a, **k: None)
+    warmed: list[bool] = []
+    monkeypatch.setattr(testenv, "juju_warmup", lambda *a, **k: warmed.append(True))
+    monkeypatch.setattr(testenv, "mark_complete", lambda: None)
+
+    result = runner.invoke(testenv.cli, ["--substrate", "lxd", "install"])
+
+    assert result.exit_code == 0, result.output
+    assert warmed == [True]
+    assert "Warming up Juju VM images" in result.output
+
+
+def test_install_skips_juju_warmup_for_maas_host_substrate(monkeypatch):
+    """MAAS-host install must not run the LXD-only juju warmup."""
+    runner = CliRunner()
+
+    monkeypatch.setattr(testenv, "install_fault_handlers", lambda name: None)
+    monkeypatch.setattr(testenv, "install_deps", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "lxd_init_cmd", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "maas_init_cmd", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "register_vm_host", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "configure_network", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "juju_init", lambda *a, **k: None)
+    monkeypatch.setattr(testenv, "_ensure_model_for_substrate", lambda *a, **k: None)
+    monkeypatch.setattr(
+        testenv,
+        "juju_warmup",
+        lambda *a, **k: pytest.fail("warmup must not run for MAAS"),
+    )
+    monkeypatch.setattr(testenv, "mark_complete", lambda: None)
+    # MAAS juju_onboard path touches state files; stub jubilant to avoid that.
+    monkeypatch.setattr(testenv, "juju_onboard", lambda *a, **k: True)
+
+    result = runner.invoke(testenv.cli, ["--substrate", "maas-host", "install"])
+
+    assert result.exit_code == 0, result.output
+    assert "Warming up Juju VM images" not in result.output


### PR DESCRIPTION
Pre-cache Juju's per-base VM images (ubuntu@22.04/24.04/26.04) by adding then removing a machine in a throwaway model during `cephtools testenv install`.