### PR TITLE
feat: support for running tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
         run: just sync
       - name: Build PEX
         run: just build-pex dist/cephtools
+      - name: Smoke-test job protocol
+        run: test "$(./dist/cephtools testenv job protocol)" = "1"
       - name: Collect metadata
         run: |
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -136,6 +136,37 @@ cephtools testenv cleanup --purge-installed
 
 `cleanup` is idempotent and best effort: if a phase has nothing to remove it is reported as skipped, later phases still run after an earlier failure, and the command exits non-zero only after printing the final summary when at least one phase failed. `--purge-installed` is intentionally destructive and cannot be combined with `--keep-*` preservation flags.
 
+### Reconnectable test jobs
+
+`cephtools testenv job` runs a long command on a prepared remote test environment without tying its lifetime to SSH. The controller and host must use releases with the same protocol, reported by `cephtools testenv job protocol`.
+
+A CI job uses three lifecycle commands:
+
+```bash
+cephtools testenv job start \
+  --target ubuntu@HOST --run-id RUN_ID \
+  --run-root /home/ubuntu/cephtools-runs \
+  --lock-file /run/lock/cephtools-testenv-job.lock \
+  --runtime-seconds 7200 --stop-timeout-seconds 300 \
+  --stage ./payload.sh payload.sh \
+  -- /home/ubuntu/cephtools-runs/RUN_ID/payload.sh
+
+cephtools testenv job wait \
+  --target ubuntu@HOST --run-id RUN_ID \
+  --run-root /home/ubuntu/cephtools-runs
+
+# Run from a separate CI `always()` finalizer.
+cephtools testenv job stop \
+  --target ubuntu@HOST --run-id RUN_ID \
+  --run-root /home/ubuntu/cephtools-runs
+```
+
+`start` checks the remote protocol, transactionally stages immutable files into an exclusively claimed run directory, refuses a busy shared host, and launches a bounded, collectable transient systemd unit. A malformed or interrupted staging transfer leaves no final run directory. The host agent holds the nonblocking lock for the payload's complete lifetime and writes output directly to `run.log`. It atomically writes `status.json`; a final `finished` or `terminated` status with a numeric exit code is authoritative even after systemd garbage-collects the transient unit. `wait` tolerates bounded SSH transport interruptions, validates every status identity, fails immediately on a definitive remote lifecycle error, and returns the payload exit code. `stop` targets only the deterministic unit for the validated run ID and is idempotent for an authoritative final state or a unit that clearly never launched. If durable status is malformed, it still performs the exact-unit stop and reports a structured best-effort outcome instead of failing the finalizer.
+
+`--stop-timeout-seconds` must be at least 10 seconds. The host agent reserves five seconds of that timeout for writing final durable status; the remainder is available to the payload process group for TERM-triggered cleanup before SIGKILL.
+
+Keep finalization in a separate CI step so it can run when waiting fails or is cancelled. `RuntimeMaxSec` remains the independent backstop if the runner cannot reconnect. Product-specific setup, cleanup, and artifact upload should remain outside the generic job lifecycle.
+
 Set `CEPHTOOLS_TERRAGRUNT_DIR` or `CEPHTOOLS_TERRAFORM_ROOT` to point at plans outside the repository. The MicroCeph Terragrunt/Terraform module now lives in the
 [charm-microceph](https://github.com/canonical/charm-microceph/tree/main/terraform/microceph) repository.
 

--- a/src/cephtools/testenv.py
+++ b/src/cephtools/testenv.py
@@ -31,6 +31,7 @@ from cephtools.testflinger import (
     read_testenv_credentials,
     read_testenv_network_config,
 )
+from cephtools.testenv_job import cli as job_cli
 
 # Fixed conventions for disposable test environments.
 DEFAULT_MAAS_VERSION = "3.7"
@@ -3289,6 +3290,8 @@ def cli(
     maas_vm_image,
 ):
     ctx.ensure_object(dict)
+    if ctx.invoked_subcommand == "job":
+        return
     ctx.obj.update(
         admin=MAAS_ADMIN,
         admin_pw=MAAS_ADMIN_PASSWORD,
@@ -4126,6 +4129,9 @@ def install(ctx):
         click.echo(f"Admin user: {ctx.obj['admin']}")
     click.echo("You can now use 'juju status' to check your controller.")
     mark_complete()
+
+
+cli.add_command(job_cli, name="job")
 
 
 def main():

--- a/src/cephtools/testenv_job.py
+++ b/src/cephtools/testenv_job.py
@@ -1,0 +1,1290 @@
+"""Detached, reconnectable jobs running on a prepared test environment."""
+
+from __future__ import annotations
+
+import datetime as dt
+import fcntl
+import io
+import json
+import os
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Sequence
+
+import click
+
+
+PROTOCOL_VERSION = 1
+DEFAULT_RUN_ROOT = "/home/ubuntu/.local/state/cephtools/jobs"
+DEFAULT_LOCK_FILE = "/run/lock/cephtools-testenv-job.lock"
+UNIT_PREFIX = "cephtools-testenv-job-"
+RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,159}$")
+TARGET_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*@[A-Za-z0-9][A-Za-z0-9_.-]*$")
+FINAL_STATES = {"finished", "terminated"}
+NONFINAL_STATES = {"launching", "running"}
+REMOTE_PREFIX = ("cephtools", "testenv", "job")
+STOP_STATUS_MARGIN_SECONDS = 5
+MIN_STOP_TIMEOUT_SECONDS = STOP_STATUS_MARGIN_SECONDS + 5
+
+
+class RemoteLifecycleError(click.ClickException):
+    """A successful SSH call reported a definitive remote lifecycle failure."""
+
+
+@dataclass(frozen=True)
+class JobPaths:
+    run_id: str
+    run_root: Path
+    run_dir: Path
+    status_file: Path
+    log_file: Path
+    unit: str
+
+    @property
+    def status(self) -> Path:
+        return self.status_file
+
+    @property
+    def log(self) -> Path:
+        return self.log_file
+
+
+def validate_run_id(value: str) -> str:
+    if not RUN_ID_RE.fullmatch(value):
+        raise click.BadParameter(
+            "must be 1-160 ASCII letters, digits, underscores, or hyphens, "
+            "and start with a letter or digit"
+        )
+    return value
+
+
+def validate_target(value: str) -> str:
+    if not TARGET_RE.fullmatch(value):
+        raise click.BadParameter("must be a conservative USER@HOST SSH target")
+    return value
+
+
+def validate_absolute_path(
+    value: str, *, label: str | None = None, name: str | None = None
+) -> Path:
+    description = label or name or "path"
+    candidate = PurePosixPath(value)
+    if (
+        not candidate.is_absolute()
+        or ".." in candidate.parts
+        or value != str(candidate)
+        or not re.fullmatch(r"/[A-Za-z0-9._/-]+", value)
+    ):
+        raise click.BadParameter(f"{description} must be a normalized absolute path")
+    return Path(str(candidate))
+
+
+def validate_relative_path(value: str) -> PurePosixPath:
+    candidate = PurePosixPath(value)
+    if (
+        not value
+        or candidate.is_absolute()
+        or ".." in candidate.parts
+        or candidate == PurePosixPath(".")
+        or value != str(candidate)
+        or any(not re.fullmatch(r"[A-Za-z0-9._-]+", part) for part in candidate.parts)
+    ):
+        raise click.BadParameter(
+            "staged destination must be a non-empty relative path without '..'"
+        )
+    return candidate
+
+
+def derive_paths(run_root: str, run_id: str) -> JobPaths:
+    run_id = validate_run_id(run_id)
+    root = validate_absolute_path(run_root, name="run root")
+    unit = f"{UNIT_PREFIX}{run_id}.service"
+    if len(unit.encode()) > 255:  # defensive if the prefix changes
+        raise click.BadParameter("derived systemd unit name is too long")
+    run_dir = root / run_id
+    return JobPaths(
+        run_id, root, run_dir, run_dir / "status.json", run_dir / "run.log", unit
+    )
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(data, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def _status_document(
+    paths: JobPaths,
+    state: str,
+    *,
+    exit_code: int | None = None,
+    started_at: str | None = None,
+    finished_at: str | None = None,
+    child_pid: int | None = None,
+    command: Sequence[str] = (),
+    termination_signal: int | None = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        "protocol": PROTOCOL_VERSION,
+        "run_id": paths.run_id,
+        "unit": paths.unit,
+        "state": state,
+        "updated_at": _utc_now(),
+    }
+    optional = {
+        "exit_code": exit_code,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "child_pid": child_pid,
+        "process_group": child_pid,
+        "argv": list(command) if command else None,
+        "termination_signal": termination_signal,
+        "message": message,
+    }
+    document.update(
+        {key: value for key, value in optional.items() if value is not None}
+    )
+    return document
+
+
+def _read_status(paths: JobPaths) -> dict[str, Any] | None:
+    try:
+        value = json.loads(paths.status.read_text())
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise click.ClickException(
+            f"Invalid durable status {paths.status}: {exc}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise click.ClickException(
+            f"Invalid durable status {paths.status}: expected object"
+        )
+    return value
+
+
+def _is_final_status(
+    status: dict[str, Any] | None, paths: JobPaths | None = None
+) -> bool:
+    if not status:
+        return False
+    exit_code = status.get("exit_code")
+    identity_matches = paths is None or (
+        status.get("run_id") == paths.run_id and status.get("unit") == paths.unit
+    )
+    return bool(
+        status.get("protocol") == PROTOCOL_VERSION
+        and identity_matches
+        and status.get("state") in FINAL_STATES
+        and isinstance(exit_code, int)
+        and not isinstance(exit_code, bool)
+        and 0 <= exit_code <= 255
+    )
+
+
+def _run_process(
+    argv: Sequence[str],
+    *,
+    input_data: bytes | None = None,
+    timeout: float | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        list(argv),
+        input=input_data,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def _remote_command(target: str, remote_argv: Sequence[str]) -> list[str]:
+    validate_target(target)
+    return ["ssh", target, shlex.join(remote_argv)]
+
+
+def run_remote(
+    target: str,
+    arguments: Sequence[str],
+    *,
+    input_bytes: bytes | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[Any]:
+    return _run_process(
+        _remote_command(target, arguments), input_data=input_bytes, timeout=timeout
+    )
+
+
+def _remote_agent(
+    target: str,
+    command: str,
+    args: Sequence[str] = (),
+    *,
+    input_data: bytes | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return run_remote(
+        target,
+        [*REMOTE_PREFIX, command, *args],
+        input_bytes=input_data,
+        timeout=timeout,
+    )
+
+
+def _text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    return value.decode(errors="replace") if isinstance(value, bytes) else value
+
+
+def _process_error(
+    action: str, result: subprocess.CompletedProcess[Any]
+) -> click.ClickException:
+    detail = _text(result.stderr).strip() or _text(result.stdout).strip()
+    return click.ClickException(f"{action} failed ({result.returncode}): {detail}")
+
+
+def _remote_agent_or_error(
+    target: str,
+    command: str,
+    args: Sequence[str],
+    *,
+    action: str,
+    input_data: bytes | None = None,
+    timeout: float,
+) -> subprocess.CompletedProcess[bytes]:
+    try:
+        return _remote_agent(
+            target,
+            command,
+            args,
+            input_data=input_data,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise click.ClickException(
+            f"{action} timed out after {timeout:g} seconds"
+        ) from exc
+
+
+def _check_protocol(target: str) -> None:
+    result = _remote_agent_or_error(
+        target,
+        "protocol",
+        (),
+        action="remote cephtools job protocol check",
+        timeout=25,
+    )
+    if result.returncode != 0:
+        raise _process_error("remote cephtools job protocol check", result)
+    remote = _text(result.stdout).strip()
+    if remote != str(PROTOCOL_VERSION):
+        raise click.ClickException(
+            f"incompatible cephtools job protocol: local={PROTOCOL_VERSION}, remote={remote!r}"
+        )
+
+
+def build_stage_archive(stage: Sequence[tuple[str, str]]) -> bytes:
+    seen: set[PurePosixPath] = set()
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        for local_text, remote_text in stage:
+            local = Path(local_text)
+            remote = validate_relative_path(remote_text)
+            if remote in seen:
+                raise click.BadParameter(f"duplicate staged destination: {remote}")
+            seen.add(remote)
+            if local.is_symlink() or not local.is_file():
+                raise click.BadParameter(
+                    f"staged source must be a regular non-symlink file: {local}"
+                )
+            info = archive.gettarinfo(str(local), arcname=str(remote))
+            info.uid = info.gid = 0
+            info.uname = info.gname = ""
+            info.mode = 0o555 if local.stat().st_mode & 0o111 else 0o444
+            with local.open("rb") as stream:
+                archive.addfile(info, stream)
+    return buffer.getvalue()
+
+
+def _safe_extract_stage(stream: Any, paths: JobPaths) -> None:
+    paths.run_root.mkdir(parents=True, exist_ok=True)
+    if os.path.lexists(paths.run_dir):
+        raise click.ClickException(f"run directory already exists: {paths.run_dir}")
+
+    staging_dir = Path(
+        tempfile.mkdtemp(prefix=f".{paths.run_id}.staging-", dir=paths.run_root)
+    )
+    seen: set[PurePosixPath] = set()
+    try:
+        with tarfile.open(fileobj=stream, mode="r|*") as archive:
+            for member in archive:
+                relative = validate_relative_path(member.name)
+                if relative in seen:
+                    raise click.ClickException(
+                        f"duplicate staged destination: {relative}"
+                    )
+                seen.add(relative)
+                if not member.isfile():
+                    raise click.ClickException(
+                        f"only regular staged files are accepted: {member.name}"
+                    )
+                destination = staging_dir.joinpath(*relative.parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                source = archive.extractfile(member)
+                if source is None:
+                    raise click.ClickException(
+                        f"could not read staged file: {member.name}"
+                    )
+                with destination.open("xb") as output:
+                    shutil.copyfileobj(source, output)
+                destination.chmod(0o555 if member.mode & 0o111 else 0o444)
+        staging_dir.chmod(0o755)
+        try:
+            staging_dir.rename(paths.run_dir)
+        except OSError as exc:
+            if os.path.lexists(paths.run_dir):
+                raise click.ClickException(
+                    f"run directory already exists: {paths.run_dir}"
+                ) from exc
+            raise
+    except click.ClickException:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+    except (tarfile.TarError, OSError) as exc:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise click.ClickException(f"invalid stage archive: {exc}") from exc
+    except BaseException:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
+
+def extract_stage_archive(paths: JobPaths, payload: bytes) -> None:
+    _safe_extract_stage(io.BytesIO(payload), paths)
+
+
+def _lock_probe(lock_file: Path) -> tuple[bool, str]:
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(lock_file, os.O_CREAT | os.O_RDWR, 0o666)
+    try:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            try:
+                diagnostics = subprocess.run(
+                    ["fuser", "-v", str(lock_file)], capture_output=True, text=True
+                )
+            except OSError:
+                return False, "lock is held"
+            detail = (diagnostics.stdout + diagnostics.stderr).strip()
+            return False, detail or "lock is held"
+        finally:
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            except OSError:
+                pass
+    finally:
+        os.close(descriptor)
+    return True, ""
+
+
+def _ancestor_pids() -> set[int]:
+    ancestors = {os.getpid()}
+    pid = os.getppid()
+    while pid > 1 and pid not in ancestors:
+        ancestors.add(pid)
+        try:
+            fields = Path(f"/proc/{pid}/stat").read_text().split()
+            pid = int(fields[3])
+        except (OSError, ValueError, IndexError):
+            break
+    return ancestors
+
+
+def preflight_host(
+    lock_file: Path,
+    active_unit_patterns: Sequence[str] = (),
+    conflict_processes: Sequence[str] = (),
+    *,
+    runner: Any = subprocess.run,
+) -> None:
+    available, detail = _lock_probe(lock_file)
+    if not available:
+        raise click.ClickException(f"test environment lock is held: {detail}")
+
+    units: list[str] = []
+    for pattern in active_unit_patterns:
+        result = runner(
+            [
+                "systemctl",
+                "list-units",
+                "--state=active,activating,deactivating",
+                "--no-legend",
+                "--no-pager",
+                pattern,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            detail = _text(result.stderr).strip() or _text(result.stdout).strip()
+            raise click.ClickException(
+                f"could not check active units matching {pattern!r}: "
+                f"{detail or f'exit {result.returncode}'}"
+            )
+        units.extend(
+            line.split()[0]
+            for line in _text(result.stdout).splitlines()
+            if line.split()
+        )
+
+    excluded = _ancestor_pids()
+    processes: list[str] = []
+    for pattern in conflict_processes:
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise click.BadParameter(
+                f"invalid conflict process regex {pattern!r}: {exc}"
+            ) from exc
+        result = runner(["pgrep", "-af", "--", pattern], capture_output=True, text=True)
+        if result.returncode not in (0, 1):
+            detail = _text(result.stderr).strip() or _text(result.stdout).strip()
+            raise click.ClickException(
+                f"could not check conflicting processes matching {pattern!r}: "
+                f"{detail or f'exit {result.returncode}'}"
+            )
+        for line in _text(result.stdout).splitlines():
+            fields = line.strip().split(maxsplit=1)
+            if fields and fields[0].isdigit() and int(fields[0]) not in excluded:
+                processes.append(line.strip())
+
+    problems: list[str] = []
+    if units:
+        problems.append("active conflicting units: " + ", ".join(sorted(set(units))))
+    if processes:
+        problems.append("conflicting host processes:\n" + "\n".join(processes))
+    if problems:
+        raise click.ClickException("\n".join(problems))
+
+
+def _systemd_properties(unit: str, *, runner: Any | None = None) -> dict[str, str]:
+    runner = runner or subprocess.run
+    result = runner(
+        [
+            "systemctl",
+            "show",
+            unit,
+            "--property",
+            "LoadState,ActiveState,SubState,Result,ExecMainStatus",
+            "--no-pager",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {"LoadState": "unknown", "error": _text(result.stderr).strip()}
+    properties: dict[str, str] = {}
+    for line in _text(result.stdout).splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            properties[key] = value
+    return properties
+
+
+def _write_status(paths: JobPaths, values: dict[str, Any]) -> None:
+    document = {
+        "protocol": PROTOCOL_VERSION,
+        "run_id": paths.run_id,
+        "unit": paths.unit,
+        "updated_at": _utc_now(),
+        **values,
+    }
+    _atomic_write_json(paths.status_file, document)
+
+
+def _durable_status_is_valid_nonfinal(
+    durable: dict[str, Any] | None, paths: JobPaths
+) -> bool:
+    if not durable:
+        return False
+    return bool(
+        durable.get("protocol") == PROTOCOL_VERSION
+        and durable.get("run_id") == paths.run_id
+        and durable.get("unit") == paths.unit
+        and durable.get("state") in NONFINAL_STATES
+        and "exit_code" not in durable
+    )
+
+
+def read_host_status(
+    paths: JobPaths, *, runner: Any = subprocess.run
+) -> dict[str, Any]:
+    lifecycle_error: dict[str, str] | None = None
+    try:
+        durable = _read_status(paths)
+    except click.ClickException as exc:
+        durable = None
+        lifecycle_error = {
+            "kind": "invalid-durable-status",
+            "message": str(exc),
+        }
+    systemd = _systemd_properties(paths.unit, runner=runner)
+    if (
+        lifecycle_error is None
+        and durable is not None
+        and not (
+            _is_final_status(durable, paths)
+            or _durable_status_is_valid_nonfinal(durable, paths)
+        )
+    ):
+        lifecycle_error = {
+            "kind": "invalid-durable-status",
+            "message": f"{paths.status} has invalid identity or state",
+        }
+    if lifecycle_error is None and not _is_final_status(durable, paths):
+        load_state = systemd.get("LoadState")
+        active_state = systemd.get("ActiveState")
+        if load_state in {None, "", "unknown"}:
+            lifecycle_error = {
+                "kind": "systemd-query-failed",
+                "message": systemd.get("error") or "systemd state is unavailable",
+            }
+        elif load_state == "not-found":
+            lifecycle_error = {
+                "kind": "unit-missing-without-final-status",
+                "message": (
+                    f"{paths.unit} is missing and no authoritative final status exists"
+                ),
+            }
+        elif active_state in {"failed", "inactive"}:
+            lifecycle_error = {
+                "kind": "unit-inactive-without-final-status",
+                "message": (
+                    f"{paths.unit} is not active and no authoritative final status exists"
+                ),
+            }
+    response: dict[str, Any] = {
+        "protocol": PROTOCOL_VERSION,
+        "run_id": paths.run_id,
+        "unit": paths.unit,
+        "status": durable or {"state": "pending"},
+        "systemd": systemd,
+    }
+    if lifecycle_error is not None:
+        response["lifecycle_error"] = lifecycle_error
+    return response
+
+
+def _host_status(paths: JobPaths) -> dict[str, Any]:
+    return read_host_status(paths)
+
+
+def _normalize_exit_code(returncode: int) -> int:
+    return 128 + abs(returncode) if returncode < 0 else returncode
+
+
+def _supervise(
+    paths: JobPaths, lock_file: Path, command: Sequence[str], kill_after: float
+) -> int:
+    if not command:
+        raise click.ClickException("payload command is required")
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_descriptor = os.open(lock_file, os.O_CREAT | os.O_RDWR, 0o666)
+    started_at = _utc_now()
+    try:
+        try:
+            fcntl.flock(lock_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            status = _status_document(
+                paths,
+                "finished",
+                exit_code=75,
+                started_at=started_at,
+                finished_at=_utc_now(),
+                command=command,
+                message="test environment lock is held",
+            )
+            _atomic_write_json(paths.status, status)
+            return 75
+
+        if not paths.run_dir.is_dir():
+            raise click.ClickException(
+                f"staged run directory is missing: {paths.run_dir}"
+            )
+        terminated_by: int | None = None
+        child: subprocess.Popen[Any] | None = None
+
+        def terminate(signum: int, _frame: Any) -> None:
+            nonlocal terminated_by
+            terminated_by = signum
+            if child is not None and child.poll() is None:
+                try:
+                    os.killpg(child.pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+
+        install_signal_handlers = threading.current_thread() is threading.main_thread()
+        previous_term: Any = None
+        previous_int: Any = None
+        if install_signal_handlers:
+            previous_term = signal.signal(signal.SIGTERM, terminate)
+            previous_int = signal.signal(signal.SIGINT, terminate)
+        try:
+            with paths.log.open("w", encoding="utf-8") as log:
+                try:
+                    child = subprocess.Popen(
+                        list(command),
+                        stdout=log,
+                        stderr=subprocess.STDOUT,
+                        start_new_session=True,
+                    )
+                except OSError as exc:
+                    log.write(f"could not start payload: {exc}\n")
+                    log.flush()
+                    _atomic_write_json(
+                        paths.status,
+                        _status_document(
+                            paths,
+                            "finished",
+                            exit_code=127,
+                            started_at=started_at,
+                            finished_at=_utc_now(),
+                            command=command,
+                            message=str(exc),
+                        ),
+                    )
+                    return 127
+                _atomic_write_json(
+                    paths.status,
+                    _status_document(
+                        paths,
+                        "running",
+                        started_at=started_at,
+                        child_pid=child.pid,
+                        command=command,
+                    ),
+                )
+                # A stop may arrive in the narrow interval before Popen assigns
+                # child. Honour it as soon as the process group exists.
+                if terminated_by is not None and child.poll() is None:
+                    try:
+                        os.killpg(child.pid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                termination_deadline: float | None = None
+                while child.poll() is None:
+                    if terminated_by is not None and termination_deadline is None:
+                        termination_deadline = time.monotonic() + kill_after
+                    if (
+                        termination_deadline is not None
+                        and time.monotonic() >= termination_deadline
+                    ):
+                        try:
+                            os.killpg(child.pid, signal.SIGKILL)
+                        except ProcessLookupError:
+                            pass
+                        termination_deadline = None
+                    time.sleep(0.1)
+                return_code = child.wait()
+        finally:
+            if install_signal_handlers:
+                signal.signal(signal.SIGTERM, previous_term)
+                signal.signal(signal.SIGINT, previous_int)
+
+        if terminated_by is not None:
+            exit_code = 128 + terminated_by
+            state = "terminated"
+        else:
+            exit_code = _normalize_exit_code(return_code)
+            state = "finished"
+        _atomic_write_json(
+            paths.status,
+            _status_document(
+                paths,
+                state,
+                exit_code=exit_code,
+                started_at=started_at,
+                finished_at=_utc_now(),
+                child_pid=child.pid,
+                command=command,
+                termination_signal=terminated_by,
+            ),
+        )
+        return exit_code
+    finally:
+        try:
+            fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(lock_descriptor)
+
+
+def run_host_job(
+    paths: JobPaths,
+    lock_file: Path,
+    command: Sequence[str],
+    *,
+    kill_after: float = 5.0,
+) -> int:
+    return _supervise(paths, lock_file, command, kill_after)
+
+
+def _common_remote_args(run_id: str, run_root: str) -> list[str]:
+    return ["--run-id", run_id, "--run-root", run_root]
+
+
+def _decode_json_output(
+    result: subprocess.CompletedProcess[bytes], action: str
+) -> dict[str, Any]:
+    if result.returncode != 0:
+        raise _process_error(action, result)
+    try:
+        value = json.loads(_text(result.stdout))
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"{action} returned invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise click.ClickException(f"{action} returned invalid JSON object")
+    return value
+
+
+def _validate_status_response(
+    response: dict[str, Any], paths: JobPaths
+) -> dict[str, Any]:
+    if response.get("protocol") != PROTOCOL_VERSION:
+        raise click.ClickException("remote job status has an incompatible protocol")
+    if response.get("run_id") != paths.run_id or response.get("unit") != paths.unit:
+        raise click.ClickException("remote job status has the wrong run identity")
+    lifecycle_error = response.get("lifecycle_error")
+    if lifecycle_error is not None:
+        if not isinstance(lifecycle_error, dict) or not isinstance(
+            lifecycle_error.get("message"), str
+        ):
+            raise click.ClickException(
+                "remote job status has a malformed lifecycle error"
+            )
+        kind = lifecycle_error.get("kind", "lifecycle-error")
+        raise RemoteLifecycleError(f"{kind}: {lifecycle_error['message']}")
+    durable = response.get("status")
+    if not isinstance(durable, dict):
+        raise click.ClickException(
+            "remote job status is missing its durable status object"
+        )
+    if durable == {"state": "pending"}:
+        return durable
+    if _is_final_status(durable, paths):
+        return durable
+    if not _durable_status_is_valid_nonfinal(durable, paths):
+        raise click.ClickException("remote job status has an invalid durable state")
+    return durable
+
+
+@click.group("job", help="Run reconnectable jobs on a prepared test environment.")
+def cli() -> None:
+    pass
+
+
+@cli.command("protocol", help="Print the testenv job protocol version.")
+def protocol_cmd() -> None:
+    click.echo(PROTOCOL_VERSION)
+
+
+@cli.command("start", context_settings={"ignore_unknown_options": True})
+@click.option("--target", required=True, callback=lambda _c, _p, v: validate_target(v))
+@click.option("--run-id", required=True, callback=lambda _c, _p, v: validate_run_id(v))
+@click.option("--run-root", default=DEFAULT_RUN_ROOT, show_default=True)
+@click.option("--lock-file", default=DEFAULT_LOCK_FILE, show_default=True)
+@click.option("--runtime-seconds", required=True, type=click.IntRange(min=1))
+@click.option(
+    "--stop-timeout-seconds",
+    default=300,
+    type=click.IntRange(min=MIN_STOP_TIMEOUT_SECONDS),
+)
+@click.option("--working-directory", default="/home/ubuntu", show_default=True)
+@click.option("--stage", nargs=2, multiple=True, metavar="LOCAL REMOTE_RELATIVE")
+@click.option("--active-unit-pattern", multiple=True)
+@click.option("--conflict-process", multiple=True)
+@click.argument("command", nargs=-1, required=True, type=click.UNPROCESSED)
+def start_cmd(
+    target: str,
+    run_id: str,
+    run_root: str,
+    lock_file: str,
+    runtime_seconds: int,
+    stop_timeout_seconds: int,
+    working_directory: str,
+    stage: tuple[tuple[str, str], ...],
+    active_unit_pattern: tuple[str, ...],
+    conflict_process: tuple[str, ...],
+    command: tuple[str, ...],
+) -> None:
+    paths = derive_paths(run_root, run_id)
+    lock = validate_absolute_path(lock_file, name="lock file")
+    working = validate_absolute_path(working_directory, name="working directory")
+    archive = build_stage_archive(stage)
+    _check_protocol(target)
+
+    stage_result = _remote_agent_or_error(
+        target,
+        "_stage",
+        _common_remote_args(run_id, str(paths.run_root)),
+        action="remote job staging",
+        input_data=archive,
+        timeout=60,
+    )
+    if stage_result.returncode != 0:
+        raise _process_error("remote job staging", stage_result)
+
+    preflight_args = [
+        *_common_remote_args(run_id, str(paths.run_root)),
+        "--lock-file",
+        str(lock),
+    ]
+    for pattern in (f"{UNIT_PREFIX}*.service", *active_unit_pattern):
+        preflight_args.extend(("--active-unit-pattern", pattern))
+    for pattern in conflict_process:
+        preflight_args.extend(("--conflict-process", pattern))
+    preflight = _remote_agent_or_error(
+        target,
+        "_preflight",
+        preflight_args,
+        action="remote job preflight",
+        timeout=25,
+    )
+    if preflight.returncode != 0:
+        raise _process_error("remote job preflight", preflight)
+
+    launch_args = [
+        *_common_remote_args(run_id, str(paths.run_root)),
+        "--lock-file",
+        str(lock),
+        "--runtime-seconds",
+        str(runtime_seconds),
+        "--stop-timeout-seconds",
+        str(stop_timeout_seconds),
+        "--working-directory",
+        str(working),
+        "--",
+        *command,
+    ]
+    launch = _remote_agent_or_error(
+        target,
+        "_start",
+        launch_args,
+        action="remote systemd launch",
+        timeout=25,
+    )
+    if launch.returncode != 0:
+        raise _process_error("remote systemd launch", launch)
+    response = _decode_json_output(launch, "remote systemd launch")
+    response["target"] = target
+    click.echo(json.dumps(response, sort_keys=True))
+
+
+@cli.command("status")
+@click.option("--target", required=True, callback=lambda _c, _p, v: validate_target(v))
+@click.option("--run-id", required=True, callback=lambda _c, _p, v: validate_run_id(v))
+@click.option("--run-root", default=DEFAULT_RUN_ROOT, show_default=True)
+@click.option("--ssh-timeout", default=25.0, type=click.FloatRange(min=0.1))
+def status_cmd(target: str, run_id: str, run_root: str, ssh_timeout: float) -> None:
+    paths = derive_paths(run_root, run_id)
+    result = _remote_agent_or_error(
+        target,
+        "_status",
+        _common_remote_args(run_id, str(paths.run_root)),
+        action="remote job status",
+        timeout=ssh_timeout,
+    )
+    response = _decode_json_output(result, "remote job status")
+    _validate_status_response(response, paths)
+    click.echo(json.dumps(response, sort_keys=True))
+
+
+@cli.command("wait")
+@click.option("--target", required=True, callback=lambda _c, _p, v: validate_target(v))
+@click.option("--run-id", required=True, callback=lambda _c, _p, v: validate_run_id(v))
+@click.option("--run-root", default=DEFAULT_RUN_ROOT, show_default=True)
+@click.option("--poll-interval", default=30.0, type=click.FloatRange(min=0.0))
+@click.option("--ssh-timeout", default=25.0, type=click.FloatRange(min=0.1))
+@click.option("--max-consecutive-errors", default=10, type=click.IntRange(min=1))
+@click.option("--tail-every", default=10, type=click.IntRange(min=1))
+@click.option("--tail-lines", default=40, type=click.IntRange(min=1))
+def wait_cmd(
+    target: str,
+    run_id: str,
+    run_root: str,
+    poll_interval: float,
+    ssh_timeout: float,
+    max_consecutive_errors: int,
+    tail_every: int,
+    tail_lines: int,
+) -> None:
+    paths = derive_paths(run_root, run_id)
+    failures = 0
+    poll_count = 0
+    while True:
+        poll_count += 1
+        try:
+            result = _remote_agent(
+                target,
+                "_status",
+                _common_remote_args(run_id, str(paths.run_root)),
+                timeout=ssh_timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            result = subprocess.CompletedProcess([], 124, b"", str(exc).encode())
+        if result.returncode == 0:
+            try:
+                response = _decode_json_output(result, "remote job status")
+                durable = _validate_status_response(response, paths)
+            except RemoteLifecycleError:
+                raise
+            except click.ClickException as exc:
+                failures += 1
+                click.echo(f"warning: {exc}", err=True)
+            else:
+                failures = 0
+                click.echo(json.dumps(response, sort_keys=True))
+                if _is_final_status(durable, paths):
+                    raise SystemExit(int(durable["exit_code"]))
+                if poll_count % tail_every == 0:
+                    try:
+                        tail = _remote_agent(
+                            target,
+                            "_tail",
+                            [
+                                *_common_remote_args(run_id, str(paths.run_root)),
+                                "--lines",
+                                str(tail_lines),
+                            ],
+                            timeout=ssh_timeout,
+                        )
+                    except subprocess.TimeoutExpired as exc:
+                        click.echo(f"warning: log tail failed: {exc}", err=True)
+                    else:
+                        if tail.returncode != 0:
+                            click.echo(
+                                "warning: log tail failed: "
+                                f"{_text(tail.stderr).strip()}",
+                                err=True,
+                            )
+                        elif tail.stdout:
+                            click.echo(_text(tail.stdout), nl=False)
+        else:
+            failures += 1
+            detail = _text(result.stderr).strip()
+            click.echo(
+                f"warning: Polling failed ({failures}/{max_consecutive_errors}): {detail}",
+                err=True,
+            )
+        if failures >= max_consecutive_errors:
+            raise click.ClickException(
+                f"lost contact with {paths.unit} after {failures} consecutive polls"
+            )
+        time.sleep(poll_interval)
+
+
+@cli.command("stop")
+@click.option("--target", required=True, callback=lambda _c, _p, v: validate_target(v))
+@click.option("--run-id", required=True, callback=lambda _c, _p, v: validate_run_id(v))
+@click.option("--run-root", default=DEFAULT_RUN_ROOT, show_default=True)
+@click.option("--attempts", default=3, type=click.IntRange(min=1))
+@click.option("--retry-delay", default=5.0, type=click.FloatRange(min=0.0))
+@click.option("--ssh-timeout", default=330.0, type=click.FloatRange(min=0.1))
+@click.option("--tail-lines", default=40, type=click.IntRange(min=1))
+def stop_cmd(
+    target: str,
+    run_id: str,
+    run_root: str,
+    attempts: int,
+    retry_delay: float,
+    ssh_timeout: float,
+    tail_lines: int,
+) -> None:
+    paths = derive_paths(run_root, run_id)
+    args = [
+        *_common_remote_args(run_id, str(paths.run_root)),
+        "--lines",
+        str(tail_lines),
+    ]
+    last: subprocess.CompletedProcess[bytes] | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            last = _remote_agent(target, "_stop", args, timeout=ssh_timeout)
+        except subprocess.TimeoutExpired as exc:
+            last = subprocess.CompletedProcess([], 124, b"", str(exc).encode())
+        if last.returncode == 0:
+            click.echo(_text(last.stdout), nl=False)
+            return
+        click.echo(
+            f"warning: finalization attempt {attempt}/{attempts} failed: "
+            f"{_text(last.stderr).strip()}",
+            err=True,
+        )
+        if attempt < attempts:
+            time.sleep(retry_delay)
+    assert last is not None
+    raise _process_error("remote job finalization", last)
+
+
+@cli.command("_stage", hidden=True)
+@click.option("--run-id", required=True)
+@click.option("--run-root", required=True)
+def stage_agent_cmd(run_id: str, run_root: str) -> None:
+    paths = derive_paths(run_root, run_id)
+    _safe_extract_stage(sys.stdin.buffer, paths)
+    click.echo(json.dumps({"run_id": run_id, "run_dir": str(paths.run_dir)}))
+
+
+@cli.command("_preflight", hidden=True)
+@click.option("--run-id", required=True)
+@click.option("--run-root", required=True)
+@click.option("--lock-file", required=True)
+@click.option("--active-unit-pattern", multiple=True)
+@click.option("--conflict-process", multiple=True)
+def preflight_agent_cmd(
+    run_id: str,
+    run_root: str,
+    lock_file: str,
+    active_unit_pattern: tuple[str, ...],
+    conflict_process: tuple[str, ...],
+) -> None:
+    paths = derive_paths(run_root, run_id)
+    if not paths.run_dir.is_dir():
+        raise click.ClickException(f"staged run directory is missing: {paths.run_dir}")
+    lock = validate_absolute_path(lock_file, name="lock file")
+    preflight_host(lock, active_unit_pattern, conflict_process)
+    click.echo(json.dumps({"state": "ready", "run_id": run_id}))
+
+
+@cli.command("_start", hidden=True, context_settings={"ignore_unknown_options": True})
+@click.option("--run-id", required=True)
+@click.option("--run-root", required=True)
+@click.option("--lock-file", required=True)
+@click.option("--runtime-seconds", required=True, type=click.IntRange(min=1))
+@click.option(
+    "--stop-timeout-seconds",
+    required=True,
+    type=click.IntRange(min=MIN_STOP_TIMEOUT_SECONDS),
+)
+@click.option("--working-directory", required=True)
+@click.argument("command", nargs=-1, required=True, type=click.UNPROCESSED)
+def launch_agent_cmd(
+    run_id: str,
+    run_root: str,
+    lock_file: str,
+    runtime_seconds: int,
+    stop_timeout_seconds: int,
+    working_directory: str,
+    command: tuple[str, ...],
+) -> None:
+    paths = derive_paths(run_root, run_id)
+    if not paths.run_dir.is_dir():
+        raise click.ClickException(f"staged run directory is missing: {paths.run_dir}")
+    lock = validate_absolute_path(lock_file, name="lock file")
+    working = validate_absolute_path(working_directory, name="working directory")
+    executable = shutil.which("cephtools")
+    if executable is None:
+        raise click.ClickException(
+            "cephtools executable is not available on the remote host"
+        )
+    _write_status(
+        paths,
+        {
+            "state": "launching",
+            "started_at": _utc_now(),
+            "argv": list(command),
+        },
+    )
+    argv = [
+        "sudo",
+        "systemd-run",
+        "--collect",
+        "--unit",
+        paths.unit,
+        "--uid",
+        "ubuntu",
+        "--gid",
+        "ubuntu",
+        "--working-directory",
+        str(working),
+        "--property",
+        "KillMode=control-group",
+        "--property",
+        f"RuntimeMaxSec={runtime_seconds}s",
+        "--property",
+        f"TimeoutStopSec={stop_timeout_seconds}s",
+        executable,
+        "testenv",
+        "job",
+        "_run",
+        "--run-id",
+        run_id,
+        "--run-root",
+        str(paths.run_root),
+        "--lock-file",
+        str(lock),
+        "--kill-after-seconds",
+        str(stop_timeout_seconds - STOP_STATUS_MARGIN_SECONDS),
+        "--",
+        *command,
+    ]
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        _write_status(
+            paths,
+            {
+                "state": "finished",
+                "exit_code": 125,
+                "started_at": _utc_now(),
+                "finished_at": _utc_now(),
+                "argv": list(command),
+                "message": (
+                    f"systemd launch failed ({result.returncode}): "
+                    f"{result.stderr.strip()}"
+                ),
+            },
+        )
+        raise click.ClickException(
+            f"systemd launch failed ({result.returncode}): {result.stderr.strip()}"
+        )
+    click.echo(
+        json.dumps(
+            {
+                "protocol": PROTOCOL_VERSION,
+                "run_id": run_id,
+                "run_dir": str(paths.run_dir),
+                "unit": paths.unit,
+                "launched": True,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+@cli.command("_run", hidden=True, context_settings={"ignore_unknown_options": True})
+@click.option("--run-id", required=True)
+@click.option("--run-root", required=True)
+@click.option("--lock-file", required=True)
+@click.option("--kill-after-seconds", default=5.0, type=click.FloatRange(min=0.1))
+@click.argument("command", nargs=-1, required=True, type=click.UNPROCESSED)
+def run_agent_cmd(
+    run_id: str,
+    run_root: str,
+    lock_file: str,
+    kill_after_seconds: float,
+    command: tuple[str, ...],
+) -> None:
+    paths = derive_paths(run_root, run_id)
+    lock = validate_absolute_path(lock_file, name="lock file")
+    raise SystemExit(_supervise(paths, lock, command, kill_after_seconds))
+
+
+@cli.command("_status", hidden=True)
+@click.option("--run-id", required=True)
+@click.option("--run-root", required=True)
+def status_agent_cmd(run_id: str, run_root: str) -> None:
+    paths = derive_paths(run_root, run_id)
+    click.echo(json.dumps(_host_status(paths), sort_keys=True))
+
+
+@cli.command("_tail", hidden=True)
+@click.option("--run-id", required=True)
+@click.option("--run-root", required=True)
+@click.option("--lines", default=40, type=click.IntRange(min=1))
+def tail_agent_cmd(run_id: str, run_root: str, lines: int) -> None:
+    paths = derive_paths(run_root, run_id)
+    try:
+        content = paths.log.read_text(errors="replace").splitlines()
+    except FileNotFoundError:
+        return
+    click.echo("\n".join(content[-lines:]))
+
+
+@cli.command("_stop", hidden=True)
+@click.option("--run-id", required=True)
+@click.option("--run-root", required=True)
+@click.option("--lines", default=40, type=click.IntRange(min=1))
+def stop_agent_cmd(run_id: str, run_root: str, lines: int) -> None:
+    paths = derive_paths(run_root, run_id)
+    active = subprocess.run(
+        ["systemctl", "is-active", "--quiet", paths.unit], capture_output=True
+    )
+    was_active = active.returncode == 0
+    if was_active:
+        stopped = subprocess.run(
+            ["sudo", "systemctl", "stop", paths.unit], capture_output=True, text=True
+        )
+        if stopped.returncode != 0:
+            raise click.ClickException(
+                f"failed to stop exact unit {paths.unit}: {stopped.stderr.strip()}"
+            )
+    status_error: dict[str, str] | None = None
+    try:
+        durable = _read_status(paths)
+    except click.ClickException as exc:
+        durable = None
+        status_error = {
+            "kind": "invalid-durable-status",
+            "message": str(exc),
+        }
+    systemd = _systemd_properties(paths.unit)
+    response = {
+        "protocol": PROTOCOL_VERSION,
+        "run_id": run_id,
+        "unit": paths.unit,
+        "durable": durable or {"state": "pending"},
+        "systemd": systemd,
+        "log_tail": (
+            "\n".join(paths.log.read_text(errors="replace").splitlines()[-lines:])
+            if paths.log.exists()
+            else ""
+        ),
+    }
+    if status_error is not None:
+        response["lifecycle_error"] = status_error
+        response["outcome"] = (
+            "stopped-with-invalid-durable-status"
+            if was_active
+            else "invalid-durable-status"
+        )
+        click.echo(json.dumps(response, sort_keys=True))
+        return
+    if _is_final_status(durable, paths):
+        click.echo(json.dumps(response, sort_keys=True))
+        return
+    if not was_active and durable is None and systemd.get("LoadState") == "not-found":
+        response["outcome"] = "never-launched"
+        click.echo(json.dumps(response, sort_keys=True))
+        return
+    detail = json.dumps(response, sort_keys=True)
+    raise click.ClickException(
+        "exact unit has no authoritative final status after stop: " + detail
+    )

--- a/src/cephtools/testflinger.py
+++ b/src/cephtools/testflinger.py
@@ -13,6 +13,7 @@ from typing import Callable, Iterable
 import click
 
 from cephtools.state import get_state_file, load_nested_yaml
+from cephtools.testenv_job import PROTOCOL_VERSION as TESTENV_JOB_PROTOCOL_VERSION
 
 
 DEFAULT_CONFIG_PATH = get_state_file("testflinger.yaml", ensure_parent=False)
@@ -570,13 +571,13 @@ def build_deploy_script(testenv_args: str | None = None) -> str:
     return "\n".join(
         [
             "set -euxo pipefail",
-            "sudo snap install astral-uv --classic",
+            "sudo wget -q -O /usr/local/bin/cephtools "
+            "https://github.com/canonical/cephtools/releases/download/latest/cephtools",
+            "sudo chmod 0755 /usr/local/bin/cephtools",
+            f'test "$(cephtools testenv job protocol)" = "{TESTENV_JOB_PROTOCOL_VERSION}"',
             "mkdir -p ~/src",
             "cd ~/src",
             "git clone https://github.com/canonical/cephtools.git",
-            "cd cephtools/",
-            "uv pip install --system --prefix ~/.local .",
-            'export PATH="$PATH:$HOME/.local/bin"',
             install_command,
             "",
         ]

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -20,7 +20,9 @@ def _run_cli(args: list[str], state_home: Path) -> subprocess.CompletedProcess[s
     )
 
 
-@pytest.mark.parametrize("args", [["--help"], ["testenv", "--help"]])
+@pytest.mark.parametrize(
+    "args", [["--help"], ["testenv", "--help"], ["testenv", "job", "--help"]]
+)
 def test_help_does_not_create_state(tmp_path: Path, args: list[str]) -> None:
     state_home = tmp_path / "state"
 
@@ -31,7 +33,9 @@ def test_help_does_not_create_state(tmp_path: Path, args: list[str]) -> None:
     assert not state_home.exists()
 
 
-@pytest.mark.parametrize("args", [["--help"], ["testenv", "--help"]])
+@pytest.mark.parametrize(
+    "args", [["--help"], ["testenv", "--help"], ["testenv", "job", "--help"]]
+)
 def test_help_ignores_legacy_config(tmp_path: Path, args: list[str]) -> None:
     state_home = tmp_path / "state"
     state_home.mkdir()
@@ -44,3 +48,13 @@ def test_help_ignores_legacy_config(tmp_path: Path, args: list[str]) -> None:
     assert "Usage:" in result.stdout
     assert legacy_config.read_text() == legacy_content
     assert sorted(path.name for path in state_home.iterdir()) == ["cephtools.yaml"]
+
+
+def test_job_protocol_does_not_create_state(tmp_path: Path) -> None:
+    state_home = tmp_path / "state"
+
+    result = _run_cli(["testenv", "job", "protocol"], state_home)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1\n"
+    assert not state_home.exists()

--- a/tests/test_testenv_job.py
+++ b/tests/test_testenv_job.py
@@ -1,0 +1,1029 @@
+from __future__ import annotations
+
+import fcntl
+import io
+import json
+import os
+import signal
+import subprocess
+import sys
+import tarfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+from click.testing import CliRunner
+
+import cephtools.testenv as testenv
+import cephtools.testenv_job as job
+
+
+def completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+def status_response(
+    status: dict[str, Any],
+    *,
+    run_id: str = "run",
+    lifecycle_error: dict[str, str] | None = None,
+) -> str:
+    response: dict[str, Any] = {
+        "protocol": job.PROTOCOL_VERSION,
+        "run_id": run_id,
+        "unit": f"cephtools-testenv-job-{run_id}.service",
+        "status": status,
+        "systemd": {"LoadState": "loaded", "ActiveState": "active"},
+    }
+    if lifecycle_error is not None:
+        response["lifecycle_error"] = lifecycle_error
+    return json.dumps(response)
+
+
+def test_job_cli_does_not_discover_primary_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        testenv, "primary_ip", lambda: (_ for _ in ()).throw(AssertionError())
+    )
+
+    result = CliRunner().invoke(testenv.cli, ["job", "protocol"])
+
+    assert result.exit_code == 0
+    assert result.output == f"{job.PROTOCOL_VERSION}\n"
+
+
+@pytest.mark.parametrize(
+    "run_id",
+    ["", "-leading", "space bad", "slash/bad", "x" * 161, "line\nbreak"],
+)
+def test_validate_run_id_rejects_unsafe_values(run_id: str) -> None:
+    with pytest.raises(click.BadParameter):
+        job.validate_run_id(run_id)
+
+
+@pytest.mark.parametrize(
+    "path", ["relative", "/tmp/../root", "/tmp//double", "/tmp/trailing/", "/tmp\nbad"]
+)
+def test_validate_absolute_path_rejects_unsafe_values(path: str) -> None:
+    with pytest.raises(click.BadParameter):
+        job.validate_absolute_path(path, label="path")
+
+
+def test_derive_paths_is_deterministic_and_exact() -> None:
+    paths = job.derive_paths("/home/ubuntu/runs", "run-1")
+
+    assert paths.run_dir == Path("/home/ubuntu/runs/run-1")
+    assert paths.status_file == paths.run_dir / "status.json"
+    assert paths.log_file == paths.run_dir / "run.log"
+    assert paths.unit == "cephtools-testenv-job-run-1.service"
+
+
+def test_stage_archive_preserves_relative_layout_and_normalizes_modes(
+    tmp_path: Path,
+) -> None:
+    script = tmp_path / "script.sh"
+    script.write_text("#!/bin/sh\necho ok\n")
+    script.chmod(0o755)
+    config = tmp_path / "job.env"
+    config.write_text("A=1\n")
+    paths = job.derive_paths(str(tmp_path / "runs"), "run-1")
+
+    payload = job.build_stage_archive(
+        [(str(script), "bin/script.sh"), (str(config), "job.env")]
+    )
+    job.extract_stage_archive(paths, payload)
+
+    assert (paths.run_dir / "bin/script.sh").read_text() == script.read_text()
+    assert (paths.run_dir / "job.env").read_text() == config.read_text()
+    assert (paths.run_dir / "bin/script.sh").stat().st_mode & 0o777 == 0o555
+    assert (paths.run_dir / "job.env").stat().st_mode & 0o777 == 0o444
+
+
+def test_stage_refuses_duplicate_run_directory(tmp_path: Path) -> None:
+    source = tmp_path / "file"
+    source.write_text("first")
+    payload = job.build_stage_archive([(str(source), "file")])
+    paths = job.derive_paths(str(tmp_path / "runs"), "same")
+    job.extract_stage_archive(paths, payload)
+
+    source.write_text("second")
+    with pytest.raises(click.ClickException):
+        job.extract_stage_archive(
+            paths, job.build_stage_archive([(str(source), "file")])
+        )
+
+    assert (paths.run_dir / "file").read_text() == "first"
+
+
+def test_stage_archive_rejects_symlink_and_duplicate_destination(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "file"
+    source.write_text("data")
+    symlink = tmp_path / "link"
+    symlink.symlink_to(source)
+
+    with pytest.raises(click.BadParameter, match="non-symlink"):
+        job.build_stage_archive([(str(symlink), "link")])
+    with pytest.raises(click.BadParameter, match="duplicate"):
+        job.build_stage_archive([(str(source), "same"), (str(source), "same")])
+
+
+def test_truncated_stage_archive_leaves_no_claimed_run_directory(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "large"
+    source.write_bytes(b"x" * 2048)
+    payload = job.build_stage_archive([(str(source), "large")])
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+
+    with pytest.raises(click.ClickException, match="invalid stage archive"):
+        job.extract_stage_archive(paths, payload[:700])
+
+    assert not paths.run_dir.exists()
+    assert not list(paths.run_root.glob(".run.staging-*"))
+
+
+def test_extract_stage_archive_rejects_traversal(tmp_path: Path) -> None:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        content = b"escape"
+        info = tarfile.TarInfo("../outside")
+        info.size = len(content)
+        archive.addfile(info, io.BytesIO(content))
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+
+    with pytest.raises(click.BadParameter):
+        job.extract_stage_archive(paths, buffer.getvalue())
+
+    assert not (tmp_path / "runs" / "outside").exists()
+
+
+def test_remote_command_quotes_each_argument_and_rejects_target_injection() -> None:
+    command = job._remote_command(
+        "ubuntu@example.test", ["printf", "%s", "hello; touch /tmp/bad"]
+    )
+
+    assert command == [
+        "ssh",
+        "ubuntu@example.test",
+        "printf %s 'hello; touch /tmp/bad'",
+    ]
+    with pytest.raises(click.BadParameter):
+        job._remote_command("ubuntu@example.test;bad", ["true"])
+    with pytest.raises(click.BadParameter):
+        job._remote_command("-bad@example.test", ["true"])
+
+
+def test_preflight_refuses_held_lock(tmp_path: Path) -> None:
+    lock_path = tmp_path / "lock"
+    lock_path.touch()
+    with lock_path.open("a+") as held:
+        fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(click.ClickException, match="lock is held"):
+            job.preflight_host(
+                lock_path,
+                runner=lambda *_args, **_kwargs: completed(),
+            )
+
+
+def test_preflight_reports_held_lock_when_fuser_is_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    lock_path = tmp_path / "lock"
+    lock_path.touch()
+    monkeypatch.setattr(
+        job.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+
+    with lock_path.open("a+") as held:
+        fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(click.ClickException, match="lock is held"):
+            job.preflight_host(lock_path)
+
+
+def test_preflight_refuses_active_unit_and_conflicting_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_runner(arguments: list[str], **_kwargs: Any):
+        if arguments[0] == "systemctl" and arguments[-1] == "legacy-*.service":
+            return completed(stdout="legacy-one.service loaded active running\n")
+        if arguments[0] == "pgrep":
+            return completed(stdout="99999 /tmp/legacy-script integration\n")
+        return completed()
+
+    monkeypatch.setattr(job, "_ancestor_pids", lambda: {os.getpid()})
+    with pytest.raises(click.ClickException) as exc_info:
+        job.preflight_host(
+            tmp_path / "lock",
+            active_unit_patterns=["legacy-*.service"],
+            conflict_processes=["legacy-script"],
+            runner=fake_runner,
+        )
+
+    message = str(exc_info.value)
+    assert "legacy-one.service" in message
+    assert "99999 /tmp/legacy-script" in message
+
+
+def test_preflight_fails_closed_when_conflict_checks_fail(tmp_path: Path) -> None:
+    def systemctl_failure(arguments: list[str], **_kwargs: Any):
+        assert arguments[0] == "systemctl"
+        return completed(1, stderr="dbus unavailable")
+
+    with pytest.raises(click.ClickException, match="dbus unavailable"):
+        job.preflight_host(
+            tmp_path / "systemctl.lock",
+            active_unit_patterns=["legacy-*.service"],
+            runner=systemctl_failure,
+        )
+
+    seen: list[str] = []
+
+    def pgrep_failure(arguments: list[str], **_kwargs: Any):
+        seen.extend(arguments)
+        return completed(2, stderr="pgrep failed")
+
+    with pytest.raises(click.ClickException, match="pgrep failed"):
+        job.preflight_host(
+            tmp_path / "pgrep.lock",
+            conflict_processes=["-legacy"],
+            runner=pgrep_failure,
+        )
+    assert seen == ["pgrep", "-af", "--", "-legacy"]
+
+
+def test_start_checks_protocol_before_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "payload"
+    source.write_text("data")
+    calls: list[list[str]] = []
+
+    def incompatible(_target: str, arguments: list[str], **_kwargs: Any):
+        calls.append(arguments)
+        return completed(stdout="999\n")
+
+    monkeypatch.setattr(job, "run_remote", incompatible)
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "start",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run-1",
+            "--run-root",
+            "/home/ubuntu/runs",
+            "--runtime-seconds",
+            "60",
+            "--stage",
+            str(source),
+            "payload",
+            "--",
+            "/bin/true",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "incompatible" in result.output
+    assert calls == [["cephtools", "testenv", "job", "protocol"]]
+
+
+def test_controller_timeouts_are_reported_as_click_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "payload"
+    source.write_text("data")
+    monkeypatch.setattr(
+        job,
+        "run_remote",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(["ssh"], 25)
+        ),
+    )
+
+    start = CliRunner().invoke(
+        job.cli,
+        [
+            "start",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run",
+            "--runtime-seconds",
+            "60",
+            "--stage",
+            str(source),
+            "payload",
+            "--",
+            "/bin/true",
+        ],
+    )
+    status = CliRunner().invoke(
+        job.cli,
+        [
+            "status",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run",
+        ],
+    )
+
+    assert start.exit_code != 0
+    assert "protocol check timed out after 25 seconds" in start.output
+    assert status.exit_code != 0
+    assert "remote job status timed out after 25 seconds" in status.output
+
+
+def test_start_stages_preflights_and_launches_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "payload"
+    source.write_text("data")
+    calls: list[tuple[list[str], dict[str, Any]]] = []
+
+    def fake_remote(_target: str, arguments: list[str], **kwargs: Any):
+        calls.append((arguments, kwargs))
+        if arguments[-1] == "protocol":
+            return completed(stdout=f"{job.PROTOCOL_VERSION}\n")
+        if "_stage" in arguments:
+            return subprocess.CompletedProcess([], 0, b"", b"")
+        if "_start" in arguments:
+            return completed(stdout='{"state":"launched"}\n')
+        return completed()
+
+    monkeypatch.setattr(job, "run_remote", fake_remote)
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "start",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run-1",
+            "--run-root",
+            "/home/ubuntu/runs",
+            "--lock-file",
+            "/run/lock/shared.lock",
+            "--runtime-seconds",
+            "99",
+            "--stop-timeout-seconds",
+            "12",
+            "--stage",
+            str(source),
+            "nested/payload",
+            "--active-unit-pattern",
+            "ceph-qa-*.service",
+            "--conflict-process",
+            "legacy-script",
+            "--",
+            "/bin/echo",
+            "hello world",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [
+        next(
+            (
+                name
+                for name in ("protocol", "_stage", "_preflight", "_start")
+                if name in call[0]
+            ),
+            "",
+        )
+        for call in calls
+    ] == [
+        "protocol",
+        "_stage",
+        "_preflight",
+        "_start",
+    ]
+    start = calls[-1][0]
+    assert "99" in start
+    assert "12" in start
+    assert start[-2:] == ["/bin/echo", "hello world"]
+    assert isinstance(calls[1][1]["input_bytes"], bytes)
+
+
+def test_start_agent_refuses_missing_staged_run(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "_start",
+            "--run-id",
+            "missing",
+            "--run-root",
+            str(tmp_path / "runs"),
+            "--lock-file",
+            str(tmp_path / "lock"),
+            "--runtime-seconds",
+            "60",
+            "--stop-timeout-seconds",
+            "10",
+            "--working-directory",
+            "/home/ubuntu",
+            "--",
+            "/bin/true",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "staged run directory is missing" in result.output
+
+
+def test_start_agent_uses_detached_bounded_exact_systemd_unit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run-1")
+    paths.run_dir.mkdir(parents=True)
+    captured: list[str] = []
+
+    def fake_run(arguments: list[str], **_kwargs: Any):
+        captured.extend(arguments)
+        return completed(stdout="launched")
+
+    monkeypatch.setattr(job.shutil, "which", lambda _name: "/usr/local/bin/cephtools")
+    monkeypatch.setattr(job.subprocess, "run", fake_run)
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "_start",
+            "--run-id",
+            "run-1",
+            "--run-root",
+            str(paths.run_root),
+            "--lock-file",
+            str(tmp_path / "lock"),
+            "--runtime-seconds",
+            "60",
+            "--stop-timeout-seconds",
+            "30",
+            "--working-directory",
+            "/home/ubuntu",
+            "--",
+            "/bin/true",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured[:2] == ["sudo", "systemd-run"]
+    assert "--collect" in captured
+    assert paths.unit in captured
+    assert "KillMode=control-group" in captured
+    assert "RuntimeMaxSec=60s" in captured
+    assert "TimeoutStopSec=30s" in captured
+    grace_index = captured.index("--kill-after-seconds")
+    assert captured[grace_index + 1] == "25"
+    assert "--pipe" not in captured
+    assert "--wait" not in captured
+    assert captured[-1] == "/bin/true"
+
+
+def test_host_job_records_output_and_exit_code(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+
+    result = job.run_host_job(
+        paths,
+        tmp_path / "lock",
+        ["bash", "-c", "echo durable-output; exit 7"],
+    )
+
+    status = json.loads(paths.status_file.read_text())
+    assert result == 7
+    assert paths.log_file.read_text() == "durable-output\n"
+    assert status["state"] == "finished"
+    assert status["exit_code"] == 7
+    assert status["argv"] == ["bash", "-c", "echo durable-output; exit 7"]
+    assert not list(paths.run_dir.glob("status.json.tmp.*"))
+
+
+def test_host_job_records_spawn_failure_as_final_status(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+
+    result = job.run_host_job(paths, tmp_path / "lock", ["/missing-command"])
+
+    status = json.loads(paths.status_file.read_text())
+    assert result == 127
+    assert status["state"] == "finished"
+    assert status["exit_code"] == 127
+    assert "could not start payload" in paths.log_file.read_text()
+
+
+def test_host_job_refuses_held_lock_and_records_final_status(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    lock_path = tmp_path / "lock"
+    lock_path.touch()
+
+    with lock_path.open("a+") as held:
+        fcntl.flock(held, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        result = job.run_host_job(paths, lock_path, ["touch", str(tmp_path / "bad")])
+
+    status = json.loads(paths.status_file.read_text())
+    assert result == 75
+    assert status["state"] == "finished"
+    assert status["exit_code"] == 75
+    assert not (tmp_path / "bad").exists()
+
+
+def test_host_job_holds_lock_for_payload_lifetime(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    lock_path = tmp_path / "lock"
+    results: list[int] = []
+    thread = threading.Thread(
+        target=lambda: results.append(
+            job.run_host_job(paths, lock_path, ["sleep", "0.4"])
+        )
+    )
+    thread.start()
+    deadline = time.time() + 2
+    while not paths.status_file.exists() and time.time() < deadline:
+        time.sleep(0.02)
+
+    with lock_path.open("a+") as contender:
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(contender, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    thread.join(timeout=2)
+
+    assert results == [0]
+
+
+def test_host_job_terminates_process_group_and_records_status(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    script = tmp_path / "parent.sh"
+    child_pid_file = tmp_path / "child.pid"
+    script.write_text(
+        "#!/bin/bash\n"
+        "trap '' TERM\n"
+        "(trap '' TERM; while true; do sleep 1; done) &\n"
+        f"echo $! > {child_pid_file}\n"
+        "while true; do sleep 1; done\n"
+    )
+    script.chmod(0o755)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from pathlib import Path; from cephtools.testenv_job import "
+                "derive_paths, run_host_job; import sys; "
+                "sys.exit(run_host_job(derive_paths(sys.argv[1], 'run'), "
+                "Path(sys.argv[2]), [sys.argv[3]], kill_after=0.2))"
+            ),
+            str(paths.run_root),
+            str(tmp_path / "lock"),
+            str(script),
+        ]
+    )
+    deadline = time.time() + 4
+    while not child_pid_file.exists() and time.time() < deadline:
+        time.sleep(0.05)
+    assert child_pid_file.exists()
+    child_pid = int(child_pid_file.read_text())
+
+    process.send_signal(signal.SIGTERM)
+    assert process.wait(timeout=5) == 143
+    status = json.loads(paths.status_file.read_text())
+    assert status["state"] == "terminated"
+    assert status["exit_code"] == 143
+    deadline = time.time() + 2
+    while Path(f"/proc/{child_pid}").exists() and time.time() < deadline:
+        time.sleep(0.05)
+    assert not Path(f"/proc/{child_pid}").exists()
+
+
+def test_host_job_allows_term_cleanup_within_configured_grace(
+    tmp_path: Path,
+) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    marker = tmp_path / "collected"
+    ready = tmp_path / "ready"
+    script = tmp_path / "collect.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        f"trap 'sleep 0.4; echo collected > {marker}; exit 0' TERM\n"
+        f"touch {ready}\n"
+        "while true; do sleep 0.1; done\n"
+    )
+    script.chmod(0o755)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from pathlib import Path; from cephtools.testenv_job import "
+                "derive_paths, run_host_job; import sys; "
+                "sys.exit(run_host_job(derive_paths(sys.argv[1], 'run'), "
+                "Path(sys.argv[2]), [sys.argv[3]], kill_after=1.5))"
+            ),
+            str(paths.run_root),
+            str(tmp_path / "lock"),
+            str(script),
+        ]
+    )
+    deadline = time.time() + 3
+    while not ready.exists() and time.time() < deadline:
+        time.sleep(0.02)
+    assert ready.exists()
+
+    process.send_signal(signal.SIGTERM)
+    assert process.wait(timeout=4) == 143
+    assert marker.read_text().strip() == "collected"
+    status = json.loads(paths.status_file.read_text())
+    assert status["state"] == "terminated"
+    assert status["exit_code"] == 143
+
+
+def test_final_status_is_authoritative_after_unit_gc(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    job._write_status(paths, {"state": "finished", "exit_code": 0})
+
+    document = job.read_host_status(
+        paths,
+        runner=lambda *_args, **_kwargs: completed(stdout="LoadState=not-found\n"),
+    )
+
+    assert document["status"]["exit_code"] == 0
+
+
+def test_missing_unit_without_final_status_is_an_error(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+
+    document = job.read_host_status(
+        paths,
+        runner=lambda *_args, **_kwargs: completed(stdout="LoadState=not-found\n"),
+    )
+
+    assert document["lifecycle_error"]["kind"] == "unit-missing-without-final-status"
+
+
+def test_stale_or_malformed_final_status_is_not_authoritative(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    paths.status_file.write_text(
+        json.dumps(
+            {
+                "protocol": job.PROTOCOL_VERSION,
+                "run_id": "another-run",
+                "unit": paths.unit,
+                "state": "finished",
+                "exit_code": 0,
+            }
+        )
+    )
+
+    document = job.read_host_status(
+        paths,
+        runner=lambda *_args, **_kwargs: completed(stdout="LoadState=not-found\n"),
+    )
+
+    assert document["lifecycle_error"]["kind"] == "invalid-durable-status"
+
+
+def test_inactive_unit_without_final_status_is_an_error(tmp_path: Path) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+
+    document = job.read_host_status(
+        paths,
+        runner=lambda *_args, **_kwargs: completed(
+            stdout="LoadState=loaded\nActiveState=failed\n"
+        ),
+    )
+
+    assert document["lifecycle_error"]["kind"] == "unit-inactive-without-final-status"
+
+
+def test_wait_tolerates_transient_failures_and_propagates_remote_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = [completed(1, stderr="offline"), completed(1, stderr="offline")]
+    responses.append(
+        completed(
+            stdout=status_response(
+                {
+                    "protocol": job.PROTOCOL_VERSION,
+                    "run_id": "run",
+                    "unit": "cephtools-testenv-job-run.service",
+                    "state": "finished",
+                    "exit_code": 7,
+                }
+            )
+        )
+    )
+    monkeypatch.setattr(job, "run_remote", lambda *_args, **_kwargs: responses.pop(0))
+    monkeypatch.setattr(job.time, "sleep", lambda _seconds: None)
+
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "wait",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run",
+            "--run-root",
+            "/tmp/runs",
+            "--poll-interval",
+            "1",
+            "--max-consecutive-errors",
+            "3",
+        ],
+    )
+
+    assert result.exit_code == 7
+    assert "Polling failed (2/3)" in result.output
+
+
+def test_wait_ignores_a_failed_periodic_log_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = [
+        completed(
+            stdout=status_response(
+                {
+                    "protocol": job.PROTOCOL_VERSION,
+                    "run_id": "run",
+                    "unit": "cephtools-testenv-job-run.service",
+                    "state": "running",
+                }
+            )
+        ),
+        subprocess.TimeoutExpired(["ssh"], 1),
+        completed(
+            stdout=status_response(
+                {
+                    "protocol": job.PROTOCOL_VERSION,
+                    "run_id": "run",
+                    "unit": "cephtools-testenv-job-run.service",
+                    "state": "finished",
+                    "exit_code": 0,
+                }
+            )
+        ),
+    ]
+
+    def fake_remote(*_args: Any, **_kwargs: Any):
+        response = responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    monkeypatch.setattr(job, "run_remote", fake_remote)
+    monkeypatch.setattr(job.time, "sleep", lambda _seconds: None)
+
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "wait",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run",
+            "--run-root",
+            "/tmp/runs",
+            "--poll-interval",
+            "0",
+            "--tail-every",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "log tail failed" in result.output
+
+
+def test_malformed_durable_status_is_a_structured_lifecycle_error(
+    tmp_path: Path,
+) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    paths.status_file.write_text("not-json")
+
+    document = job.read_host_status(
+        paths,
+        runner=lambda *_args, **_kwargs: completed(
+            stdout="LoadState=loaded\nActiveState=active\n"
+        ),
+    )
+
+    assert document["lifecycle_error"]["kind"] == "invalid-durable-status"
+    with pytest.raises(job.RemoteLifecycleError):
+        job._validate_status_response(document, paths)
+
+
+def test_wait_fails_immediately_on_definitive_lifecycle_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def remote(*_args: Any, **_kwargs: Any):
+        nonlocal calls
+        calls += 1
+        return completed(
+            stdout=status_response(
+                {"state": "launching"},
+                lifecycle_error={
+                    "kind": "unit-inactive-without-final-status",
+                    "message": "service failed before durable completion",
+                },
+            )
+        )
+
+    monkeypatch.setattr(job, "run_remote", remote)
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "wait",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run",
+            "--run-root",
+            "/tmp/runs",
+            "--poll-interval",
+            "0",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "service failed before durable completion" in result.output
+    assert "lost contact" not in result.output
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda response: response.update(protocol=999),
+        lambda response: response.update(run_id="wrong"),
+        lambda response: response.update(unit="wrong.service"),
+        lambda response: response["status"].update(state="unknown"),
+    ],
+)
+def test_status_response_validation_rejects_wrong_envelope_and_state(
+    mutation: Any,
+) -> None:
+    paths = job.derive_paths("/tmp/runs", "run")
+    response = json.loads(
+        status_response(
+            {
+                "protocol": job.PROTOCOL_VERSION,
+                "run_id": "run",
+                "unit": paths.unit,
+                "state": "running",
+            }
+        )
+    )
+    mutation(response)
+
+    with pytest.raises(click.ClickException):
+        job._validate_status_response(response, paths)
+
+
+def test_wait_fails_at_configured_error_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(job, "run_remote", lambda *_args, **_kwargs: completed(1))
+    monkeypatch.setattr(job.time, "sleep", lambda _seconds: None)
+
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "wait",
+            "--target",
+            "ubuntu@example.test",
+            "--run-id",
+            "run",
+            "--run-root",
+            "/tmp/runs",
+            "--poll-interval",
+            "1",
+            "--max-consecutive-errors",
+            "2",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "lost contact" in result.output
+
+
+def test_stop_agent_targets_only_the_exact_derived_unit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    job._write_status(paths, {"state": "terminated", "exit_code": 143})
+    calls: list[list[str]] = []
+
+    def fake_run(arguments: list[str], **_kwargs: Any):
+        calls.append(arguments)
+        if arguments[:3] == ["systemctl", "is-active", "--quiet"]:
+            return completed()
+        if arguments[:3] == ["sudo", "systemctl", "stop"]:
+            return completed()
+        return completed(stdout="LoadState=not-found\n")
+
+    monkeypatch.setattr(job.subprocess, "run", fake_run)
+    result = CliRunner().invoke(
+        job.cli,
+        [
+            "_stop",
+            "--run-id",
+            "run",
+            "--run-root",
+            str(paths.run_root),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ["sudo", "systemctl", "stop", paths.unit] in calls
+    assert all("*" not in argument for call in calls for argument in call)
+
+
+def test_stop_agent_reports_malformed_status_after_best_effort_stop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    paths.status_file.write_text("{truncated")
+    calls: list[list[str]] = []
+
+    def fake_run(arguments: list[str], **_kwargs: Any):
+        calls.append(arguments)
+        if arguments[:3] == ["systemctl", "is-active", "--quiet"]:
+            return completed()
+        if arguments[:3] == ["sudo", "systemctl", "stop"]:
+            return completed()
+        return completed(stdout="LoadState=not-found\n")
+
+    monkeypatch.setattr(job.subprocess, "run", fake_run)
+    result = CliRunner().invoke(
+        job.cli,
+        ["_stop", "--run-id", "run", "--run-root", str(paths.run_root)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert ["sudo", "systemctl", "stop", paths.unit] in calls
+    response = json.loads(result.output)
+    assert response["outcome"] == "stopped-with-invalid-durable-status"
+    assert response["lifecycle_error"]["kind"] == "invalid-durable-status"
+    assert "Invalid durable status" in response["lifecycle_error"]["message"]
+
+
+def test_stop_agent_is_idempotent_for_never_launched_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+
+    def fake_run(arguments: list[str], **_kwargs: Any):
+        if arguments[:3] == ["systemctl", "is-active", "--quiet"]:
+            return completed(4)
+        return completed(stdout="LoadState=not-found\n")
+
+    monkeypatch.setattr(job.subprocess, "run", fake_run)
+    result = CliRunner().invoke(
+        job.cli,
+        ["_stop", "--run-id", "run", "--run-root", str(paths.run_root)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert '"outcome": "never-launched"' in result.output
+
+
+def test_stop_agent_rejects_failed_unit_without_final_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = job.derive_paths(str(tmp_path / "runs"), "run")
+    paths.run_dir.mkdir(parents=True)
+    job._write_status(paths, {"state": "launching"})
+
+    def fake_run(arguments: list[str], **_kwargs: Any):
+        if arguments[:3] == ["systemctl", "is-active", "--quiet"]:
+            return completed(3)
+        return completed(stdout="LoadState=loaded\nActiveState=failed\n")
+
+    monkeypatch.setattr(job.subprocess, "run", fake_run)
+    result = CliRunner().invoke(
+        job.cli,
+        ["_stop", "--run-id", "run", "--run-root", str(paths.run_root)],
+    )
+
+    assert result.exit_code != 0
+    assert "no authoritative final status" in result.output
+    assert '"ActiveState": "failed"' in result.output

--- a/tests/test_testflinger.py
+++ b/tests/test_testflinger.py
@@ -373,11 +373,13 @@ def test_ensure_backend_config_creates_and_loads(tmp_path: Path) -> None:
 
 def test_build_deploy_script() -> None:
     script = build_deploy_script()
-    assert "snap install astral-uv --classic" in script
+    assert "releases/download/latest/cephtools" in script
+    assert "sudo chmod 0755 /usr/local/bin/cephtools" in script
+    assert 'test "$(cephtools testenv job protocol)" = "1"' in script
     assert "mkdir -p ~/src" in script
     assert "cd ~/src" in script
     assert "git clone https://github.com/canonical/cephtools.git" in script
-    assert 'export PATH="$PATH:$HOME/.local/bin"' in script
+    assert "uv pip install" not in script
     assert script.strip().endswith("cephtools testenv install")
 
 


### PR DESCRIPTION
Add cephtools testenv job for safely running long-lived commands on prepared remote test environments.

 - Adds start, wait, status, stop, and protocol commands.
 - Runs jobs as detached, bounded transient systemd units.
 - Supports transactional file staging, shared host locking, reconnectable polling, and exact-unit finalization.
 - Writes direct remote logs and atomic durable JSON status.
 - Preserves exit codes and handles process-group termination.


Assisted-by: pi:gpt-5.6-sol